### PR TITLE
Add constant dictionary upload

### DIFF
--- a/Database/DatabaseCore.cs
+++ b/Database/DatabaseCore.cs
@@ -383,6 +383,44 @@ namespace Database
             }
         }
 
+        public void AddDictionary(string name, List<string> contents)
+        {
+            using (var connection = GetConnection())
+            {
+                DictionaryNameEntity nameEntity = new DictionaryNameEntity();
+                nameEntity.name = name;
+
+                connection.Open();
+                nameEntity.id = connection.Query<int>(
+                    @"INSERT INTO dictionary_name
+                    ( name ) VALUES 
+                    ( @name )
+                    RETURNING id;", nameEntity).First();
+
+                foreach(string value in contents)
+                {
+                    DictionaryEntryEntity entry = new DictionaryEntryEntity();
+                    entry.dictionary_id = nameEntity.id.Value;
+                    entry.content = value;
+
+                    connection.Execute(@"INSERT INTO dictionary_entry
+                    ( content, dictionary_id ) VALUES
+                    ( @content, @dictionary_id );", entry);
+                }
+            }
+        }
+
+        public async Task<List<string>> GetAllDictionaryEntries()
+        {
+            using (IDbConnection conn = GetConnection())
+            {
+                string sQuery = "SELECT content FROM dictionary_entry";
+                conn.Open();
+                var result = await conn.QueryAsync<string>(sQuery);
+                return result.ToList();
+            }
+        }
+
         public async Task AddRequestSequence(RequestSequence sequence, FuzzerRunEntity run)
         {
             RequestSequenceEntity model = new RequestSequenceEntity();

--- a/Database/DatabaseHelper.cs
+++ b/Database/DatabaseHelper.cs
@@ -134,6 +134,21 @@ namespace Database
                         execution_time      TIME        NOT NULL,
                         executed_requests   INTEGER     NOT NULL
                     );");
+
+                // Dictionary metadata.
+                connection.Execute(
+                    @"CREATE TABLE dictionary_name (
+                        id                  SERIAL      PRIMARY KEY,
+                        name                TEXT        NOT NULL
+                    );");
+
+                // Dictionary entries.
+                connection.Execute(
+                    @"CREATE TABLE dictionary_entry (
+                        id                  SERIAL      PRIMARY KEY,
+                        dictionary_id       INTEGER     NOT NULL,
+                        content             TEXT        NOT NULL
+                    );");
             }
         }
 

--- a/Database/Entities/DictionaryEntryEntity.cs
+++ b/Database/Entities/DictionaryEntryEntity.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Database.Entities
+{
+    public class DictionaryEntryEntity
+    {
+        public int? id { get; set; }
+        public int dictionary_id { get; set; }
+        public string content { get; set; }
+    }
+}

--- a/Database/Entities/DictionaryNameEntity.cs
+++ b/Database/Entities/DictionaryNameEntity.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Database.Entities
+{
+    class DictionaryNameEntity
+    {
+        public int? id { get; set; }
+        public string name { get; set; }
+    }
+}

--- a/Database/Repositories/IFuzzerRepository.cs
+++ b/Database/Repositories/IFuzzerRepository.cs
@@ -47,5 +47,8 @@ namespace Database.Repositories
         // Fuzzer Runs
         Task<List<FuzzerRunEntity>> GetAllFuzzerRuns();
         Task<List<FuzzerGenerationEntity>> GetFuzzerGenerationByRun(int id);
+
+        // Dictionaries
+        void AddDictionary(string name, List<string> contents);
     }
 }

--- a/Fuzz/Program.cs
+++ b/Fuzz/Program.cs
@@ -24,7 +24,6 @@ namespace Fuzz
 
         static async Task Main(string[] args)
         {
-            //string fuzzerConfig = System.IO.File.ReadAllText(@"C:\Users\Richa\Documents\RiverFuzzResources\Wordpress\FuzzerConfig\fuzz.json");
             string fuzzerConfig = System.IO.File.ReadAllText(@"fuzz.json");
             JObject config = JObject.Parse(fuzzerConfig);
             
@@ -74,8 +73,9 @@ namespace Fuzz
             List<IGenerator> generators = new List<IGenerator>();
             generators.Add(new BestKnownMatchGenerator());
             generators.Add(new RemoveTokenGenerator(50));
-            generators.Add(new DictionarySubstitutionGenerator(@"C:\Users\Richa\Documents\Tools\Lists\blns.txt", 10));
-            // generators.Add(new DictionarySubstitutionGenerator(@"C:\Users\Richa\Documents\Tools\Lists\xss_payloads_quick.txt", 10));
+
+            List<string> dictionary = await databaseHelper.GetAllDictionaryEntries();
+            generators.Add(new DictionarySubstitutionGenerator(dictionary, 10));
 
             // Parse the list of endpoints we should include in this run, then load them.
             DatabaseLoader databaseParse = new DatabaseLoader(databaseHelper, config.Value<string>("Target"));
@@ -220,8 +220,6 @@ namespace Fuzz
                     await databaseHelper.AddRequestSequence(sequence, runInfo);
                 }     
             }
-
-            
         }
     }
 }

--- a/Generators/DictionarySubstitutionGenerator.cs
+++ b/Generators/DictionarySubstitutionGenerator.cs
@@ -11,12 +11,12 @@ namespace Generators
     {
         public int MaxSubstitutions { get; }
 
-        private string[] dictionary;
+        private List<string> dictionary;
         private Random rand;
-        public DictionarySubstitutionGenerator(string dictionaryPath, int maxSubstitutions)
+        public DictionarySubstitutionGenerator(List<string> entries, int maxSubstitutions)
         {
             MaxSubstitutions = maxSubstitutions;
-            dictionary = System.IO.File.ReadAllLines(dictionaryPath);
+            dictionary = entries;
             rand = new Random();
         }
 
@@ -43,7 +43,7 @@ namespace Generators
                 ISubstitution sub = newSequence.Get(selectedStage).Substitutions[subIndex];
                 newSequence.Get(selectedStage).Substitutions.RemoveAt(subIndex);
 
-                string replacement = dictionary[rand.Next(0, dictionary.Length)];
+                string replacement = dictionary[rand.Next(0, dictionary.Count)];
                 SubstituteConstant substituteConstant = new SubstituteConstant(sub.GetTarget(), replacement);
                 newSequence.Get(selectedStage).Substitutions.Add(substituteConstant);
 

--- a/WebView/Controllers/DictionaryController.cs
+++ b/WebView/Controllers/DictionaryController.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Database.Repositories;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using WebView.Models;
+
+// For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace WebView.Controllers
+{
+    public class DictionaryController : Controller
+    {
+        private readonly ILogger<EndpointsController> _logger;
+        private readonly IFuzzerRepository _endpointRepository;
+
+        public DictionaryController(ILogger<EndpointsController> logger, IFuzzerRepository endpointRepo)
+        {
+            _logger = logger;
+            _endpointRepository = endpointRepo;
+        }
+
+        public IActionResult AddFromFile()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [Route("Dictionary/API/AddFromFile")]
+        public IActionResult APIAddEndpointFromFile(DictionaryUploadViewModel model)
+        {
+            foreach (IFormFile file in model.Files)
+            {
+                StreamReader sr = new StreamReader(file.OpenReadStream());
+
+                List<string> entries = new List<string>();
+                string? content = sr.ReadLine();
+                while (content != null)
+                {
+                    entries.Add(content);
+                    content = sr.ReadLine();
+                }
+
+                _endpointRepository.AddDictionary(model.Name, entries);
+            }
+            return RedirectToAction("AddFromFile");
+        }
+    }
+}

--- a/WebView/Models/DictionaryUploadViewModel.cs
+++ b/WebView/Models/DictionaryUploadViewModel.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebView.Models
+{
+    public class DictionaryUploadViewModel
+    {
+        public DictionaryUploadViewModel()
+        {
+            Files = new List<IFormFile>();
+            Name = String.Empty;
+        }
+
+        public IEnumerable<IFormFile> Files { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/WebView/Views/Dictionary/AddFromFile.cshtml
+++ b/WebView/Views/Dictionary/AddFromFile.cshtml
@@ -1,0 +1,26 @@
+﻿@model DictionaryUploadViewModel
+@using  WebView.Models.Services
+@inject ParserService ParseService
+@{
+    ViewData["Title"] = "Upload Dictionaries";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<form enctype="multipart/form-data" method="post" asp-controller="Dictionary" asp-action="APIAddEndpointFromFile">
+    <dl>
+        <dt>
+            <label asp-for="Name"></label>
+        </dt>
+        <dd>
+            <input asp-for="Name" type="text">
+        </dd>
+        <dt>
+            <label asp-for="Files"></label>
+        </dt>
+        <dd>
+            <input asp-for="Files" type="file" multiple>
+        </dd>
+    </dl>
+    <input class="btn btn-primary" type="submit" />
+</form>

--- a/WebView/Views/Shared/_Layout.cshtml
+++ b/WebView/Views/Shared/_Layout.cshtml
@@ -29,6 +29,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Results" asp-action="Statistics">Run Statistics</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Dictionary" asp-action="AddFromFile">Add Dictionary</a>
+                        </li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
It isn't super clean, but this change adds the ability to upload "dictionaries", which are just lists of constant values that we feed into the fuzzer. Right now you can only upload dictionaries -- there's no way to view or delete them.

Fixes: #12 